### PR TITLE
chore(deps): bump brace-expansion to 5.0.9 (GHSA-rgw5-rvv9-x895)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5256,9 +5256,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@types/react-dom": "19.2.3",
     "postcss": "^8.5.24",
     "uuid": "^14.0.0",
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "sharp": "^0.35.3"
   }
 }


### PR DESCRIPTION
## Summary

Resolves the one remaining high-severity advisory reported by `npm audit`.

`brace-expansion` 5.0.8 → 5.0.9 — [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895): DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation.

Applied via `npm audit fix`, plus the `overrides` floor in `package.json` raised from `^5.0.8` to `^5.0.9` so a fresh install cannot resolve back to the vulnerable version.

## Scope

Dev-only dependency — pulled in by `eslint`, `typescript-eslint` and `jest` via `minimatch`. No runtime exposure in the storefront build.

## Verification

- `npm audit` → **found 0 vulnerabilities** (was: 1 high)
- `npm test` (prettier check) → pass
- `npm run jest` → 3 pre-existing failures in `lib/r2o/index.spec.ts` (`prepareCustomerData is not a function`), identical on `main` at 9686b1e without this change. Unrelated to this bump, tracked separately.

## Note

The GitHub `sharp` alert email (GHSA-f88m-g3jw-g9cj) that prompted this check is already resolved — `sharp@0.35.3` is installed, the advisory affects `< 0.35.0`, and the Dependabot alert has been in `fixed` state since 2026-07-28. Open Dependabot alerts on this repo: 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016WxYyaiBRDgSnyYa1vgxzt